### PR TITLE
color themeを追加

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,9 +16,7 @@ import 'package:quick_flutter/firebase_options.dart';
 import 'package:quick_flutter/model/analytics_event/analytics_event_name.dart';
 import 'package:quick_flutter/screen/settings/settings_screen.dart';
 import 'package:quick_flutter/screen/todo_screen/todo_screen.dart';
-import 'package:quick_flutter/systems/color.dart';
 import 'package:quick_flutter/controller/url/url_controller.dart';
-import 'package:quick_flutter/systems/context_extension.dart';
 import 'package:quick_flutter/widget/actions/close_window/close_window_action.dart';
 import 'package:quick_flutter/widget/actions/delete_todo/delete_todo_action.dart';
 import 'package:quick_flutter/widget/actions/focus_down/focus_down_action.dart';
@@ -30,6 +28,7 @@ import 'package:quick_flutter/widget/actions/new_todo_below/new_todo_below_actio
 import 'package:quick_flutter/widget/actions/pin_window/pin_window_action.dart';
 import 'package:quick_flutter/widget/actions/toggle_todo_done/toggle_todo_done_action.dart';
 import 'package:quick_flutter/widget/shortcutkey.dart';
+import 'package:quick_flutter/widget/theme/app_theme.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -66,6 +65,7 @@ void main() async {
                 });
 
                 return Material(
+                  color: context.appColors.backgroundDefault,
                   child: SingleChildScrollView(
                     child: NotificationListener<SizeChangedLayoutNotification>(
                       onNotification: (notification) {
@@ -189,8 +189,8 @@ class _Header extends ConsumerWidget {
                   bookmark ? Icons.push_pin : Icons.push_pin_outlined,
                 ),
                 color: bookmark
-                    ? context.colorScheme.primary
-                    : context.colorScheme.secondary,
+                    ? context.appColors.backgroundPrimaryActionEnabled
+                    : null,
               ),
               IconButton(
                 focusNode: FocusNode(skipTraversal: true),
@@ -511,15 +511,9 @@ class AppMaterialApp extends MaterialApp {
           home: home,
           title: 'Flutter Demo',
           debugShowCheckedModeBanner: false,
-          theme: ThemeData(
-            colorScheme: ColorScheme.fromSeed(
-              seedColor: AppColor.seed,
-              outline: AppColor.outline,
-              outlineVariant: AppColor.outlineVariant,
-              shadow: AppColor.shadow,
-            ),
-            useMaterial3: true,
-          ),
+          theme: AppTheme.light,
+          darkTheme: AppTheme.dark,
+          themeMode: ThemeMode.light,
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
         );

--- a/lib/screen/settings/settings_screen.dart
+++ b/lib/screen/settings/settings_screen.dart
@@ -5,6 +5,7 @@ import 'package:quick_flutter/controller/hot_key/hot_key_controller.dart';
 import 'package:quick_flutter/controller/screen_type/screen_type_controller.dart';
 import 'package:quick_flutter/systems/context_extension.dart';
 import 'package:quick_flutter/systems/keyboard_key_extension.dart';
+import 'package:quick_flutter/widget/theme/app_theme.dart';
 
 class SettingsScreen extends HookConsumerWidget {
   const SettingsScreen({super.key});
@@ -110,11 +111,11 @@ class _HotkeyItem extends HookConsumerWidget {
       children: [
         Text(
           'Hotkey',
-          style: context.textTheme.titleSmall,
+          style: context.appTextTheme.labelMidium,
         ),
         Text(
           'Open or hide the panel with a hotkey.',
-          style: context.textTheme.bodySmall,
+          style: context.appTextTheme.bodySmall,
         ),
         const SizedBox(height: 8),
         Row(
@@ -132,7 +133,10 @@ class _HotkeyItem extends HookConsumerWidget {
                             .toggleModifier(modifier);
                       },
                     ),
-                    Text(modifier.shortcutLabel),
+                    Text(
+                      modifier.shortcutLabel,
+                      style: context.appTextTheme.labelMidium,
+                    ),
                   ],
                 ),
               ),
@@ -154,7 +158,10 @@ class _HotkeyItem extends HookConsumerWidget {
                   },
                   child: Row(
                     children: [
-                      Text(selectedKey?.shortcutLabel ?? 'Key'),
+                      Text(
+                        selectedKey?.shortcutLabel ?? 'Key',
+                        style: context.appTextTheme.labelMidium,
+                      ),
                       const Icon(Icons.arrow_drop_down),
                     ],
                   ),
@@ -168,7 +175,10 @@ class _HotkeyItem extends HookConsumerWidget {
                         .read(hotKeyControllerProvider.notifier)
                         .setKey(keys[index]);
                   },
-                  child: Text(keys[index].shortcutLabel),
+                  child: Text(
+                    keys[index].shortcutLabel,
+                    style: context.appTextTheme.labelMidium,
+                  ),
                 ),
               ),
             ),
@@ -178,7 +188,7 @@ class _HotkeyItem extends HookConsumerWidget {
           Text(
             ref.watch(hotKeyControllerProvider).error.toString(),
             style: context.textTheme.labelMedium!.copyWith(
-              color: context.colorScheme.error,
+              color: context.appColors.textDanger,
             ),
           ),
       ],

--- a/lib/screen/todo_screen/todo_list.dart
+++ b/lib/screen/todo_screen/todo_list.dart
@@ -232,7 +232,7 @@ class TodoListItem extends HookConsumerWidget {
             child: Container(
               decoration: BoxDecoration(
                 color: hasFocus.value
-                    ? context.colorScheme.primary.withOpacity(0.1)
+                    ? context.appColors.backgroundPrimaryContainer
                     : Colors.transparent,
                 borderRadius: BorderRadius.circular(4),
               ),
@@ -289,8 +289,10 @@ class TodoListItem extends HookConsumerWidget {
                       child: TextField(
                         controller: controller,
                         focusNode: focusNode,
-                        style: context.textTheme.bodyLarge!.copyWith(
-                          color: todo.isDone ? Colors.grey : Colors.black,
+                        style: context.appTextTheme.bodyLarge.copyWith(
+                          color: todo.isDone
+                              ? Colors.grey
+                              : context.appColors.textDefault,
                         ),
                         maxLines: null,
                         decoration: const InputDecoration(

--- a/lib/screen/todo_screen/todo_screen.dart
+++ b/lib/screen/todo_screen/todo_screen.dart
@@ -22,6 +22,7 @@ import 'package:quick_flutter/widget/actions/new_todo_below/new_todo_below_actio
 import 'package:quick_flutter/widget/actions/toggle_todo_done/toggle_todo_done_action.dart';
 import 'package:quick_flutter/widget/markdown_text_editing_controller.dart';
 import 'package:quick_flutter/widget/markdown_text_field.dart';
+import 'package:quick_flutter/widget/theme/app_theme.dart';
 
 part 'todo_list.dart';
 part 'memo.dart';

--- a/lib/screen/todo_screen/todo_screen.dart
+++ b/lib/screen/todo_screen/todo_screen.dart
@@ -12,7 +12,6 @@ import 'package:quick_flutter/controller/todo_text_editing_controller/todo_text_
 import 'package:quick_flutter/controller/todo_text_field_focus/todo_text_field_focus_controller.dart';
 import 'package:quick_flutter/model/analytics_event/analytics_event_name.dart';
 import 'package:quick_flutter/model/todo/todo.dart';
-import 'package:quick_flutter/systems/context_extension.dart';
 import 'package:quick_flutter/widget/actions/delete_todo/delete_todo_action.dart';
 import 'package:quick_flutter/widget/actions/focus_down/focus_down_action.dart';
 import 'package:quick_flutter/widget/actions/focus_up/focus_up_action.dart';

--- a/lib/screen/todo_screen/todo_text_field.dart
+++ b/lib/screen/todo_screen/todo_text_field.dart
@@ -104,7 +104,7 @@ class _TodoTextField extends HookConsumerWidget {
               ),
               const SizedBox(width: 4),
               IconButton(
-                color: context.colorScheme.primary,
+                color: context.appColors.backgroundPrimaryActionEnabled,
                 onPressed: canSubmit.value
                     ? () {
                         _addTodo(ref, controller, focusNode);

--- a/lib/widget/theme/app_color_theme_extension.dart
+++ b/lib/widget/theme/app_color_theme_extension.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+
+class AppColorsExtension extends ThemeExtension<AppColorsExtension> {
+  AppColorsExtension({
+    required this.textDefault,
+    required this.textSubtle,
+    required this.textDisabled,
+    required this.textDanger,
+    required this.textSuccess,
+    required this.backgroundDefault,
+    required this.backgroundSubtle,
+    required this.backgroundPrimaryContainer,
+    required this.backgroundPrimaryActionEnabled,
+    required this.backgroundPrimaryActionDisabled,
+    required this.backgroundPrimaryActionHovered,
+  });
+
+  // Text
+  final Color textDefault;
+  final Color textSubtle;
+  final Color textDisabled;
+  final Color textDanger;
+  final Color textSuccess;
+
+  // background
+  final Color backgroundDefault;
+  final Color backgroundSubtle;
+  final Color backgroundPrimaryContainer;
+
+  // background/primary-action
+  final Color backgroundPrimaryActionEnabled;
+  final Color backgroundPrimaryActionDisabled;
+  final Color backgroundPrimaryActionHovered;
+
+  @override
+  ThemeExtension<AppColorsExtension> copyWith({
+    Color? textDefault,
+    Color? textSubtle,
+    Color? textDisabled,
+    Color? textDanger,
+    Color? textSuccess,
+    Color? backgroundDefault,
+    Color? backgroundSubtle,
+    Color? backgroundPrimaryContainer,
+    Color? backgroundPrimaryActionEnabled,
+    Color? backgroundPrimaryActionDisabled,
+    Color? backgroundPrimaryActionHovered,
+  }) {
+    return AppColorsExtension(
+      textDefault: textDefault ?? this.textDefault,
+      textSubtle: textSubtle ?? this.textSubtle,
+      textDisabled: textDisabled ?? this.textDisabled,
+      textDanger: textDanger ?? this.textDanger,
+      textSuccess: textSuccess ?? this.textSuccess,
+      backgroundDefault: backgroundDefault ?? this.backgroundDefault,
+      backgroundSubtle: backgroundSubtle ?? this.backgroundSubtle,
+      backgroundPrimaryContainer:
+          backgroundPrimaryContainer ?? this.backgroundPrimaryContainer,
+      backgroundPrimaryActionEnabled:
+          backgroundPrimaryActionEnabled ?? this.backgroundPrimaryActionEnabled,
+      backgroundPrimaryActionDisabled: backgroundPrimaryActionDisabled ??
+          this.backgroundPrimaryActionDisabled,
+      backgroundPrimaryActionHovered:
+          backgroundPrimaryActionHovered ?? this.backgroundPrimaryActionHovered,
+    );
+  }
+
+  @override
+  ThemeExtension<AppColorsExtension> lerp(
+    covariant ThemeExtension<AppColorsExtension>? other,
+    double t,
+  ) {
+    if (other is! AppColorsExtension) {
+      return this;
+    }
+
+    return AppColorsExtension(
+      textDefault: Color.lerp(textDefault, other.textDefault, t)!,
+      textSubtle: Color.lerp(textSubtle, other.textSubtle, t)!,
+      textDisabled: Color.lerp(textDisabled, other.textDisabled, t)!,
+      textDanger: Color.lerp(textDanger, other.textDanger, t)!,
+      textSuccess: Color.lerp(textSuccess, other.textSuccess, t)!,
+      backgroundDefault:
+          Color.lerp(backgroundDefault, other.backgroundDefault, t)!,
+      backgroundSubtle:
+          Color.lerp(backgroundSubtle, other.backgroundSubtle, t)!,
+      backgroundPrimaryContainer: Color.lerp(
+        backgroundPrimaryContainer,
+        other.backgroundPrimaryContainer,
+        t,
+      )!,
+      backgroundPrimaryActionEnabled: Color.lerp(
+        backgroundPrimaryActionEnabled,
+        other.backgroundPrimaryActionEnabled,
+        t,
+      )!,
+      backgroundPrimaryActionDisabled: Color.lerp(
+        backgroundPrimaryActionDisabled,
+        other.backgroundPrimaryActionDisabled,
+        t,
+      )!,
+      backgroundPrimaryActionHovered: Color.lerp(
+        backgroundPrimaryActionHovered,
+        other.backgroundPrimaryActionHovered,
+        t,
+      )!,
+    );
+  }
+}

--- a/lib/widget/theme/app_text_theme_extension.dart
+++ b/lib/widget/theme/app_text_theme_extension.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+
+class AppTextThemeExtension extends ThemeExtension<AppTextThemeExtension> {
+  const AppTextThemeExtension({
+    required this.displayLarge,
+    required this.displayMedium,
+    required this.displaySmall,
+    required this.headlineLarge,
+    required this.headlineMedium,
+    required this.headlineSmall,
+    required this.titleLarge,
+    required this.titleMedium,
+    required this.titleSmall,
+    required this.bodyLarge,
+    required this.bodyMedium,
+    required this.bodySmall,
+    required this.labelLarge,
+    required this.labelMidium,
+    required this.labelSmall,
+  });
+
+  final TextStyle displayLarge;
+  final TextStyle displayMedium;
+  final TextStyle displaySmall;
+  final TextStyle headlineLarge;
+  final TextStyle headlineMedium;
+  final TextStyle headlineSmall;
+  final TextStyle titleLarge;
+  final TextStyle titleMedium;
+  final TextStyle titleSmall;
+  final TextStyle bodyLarge;
+  final TextStyle bodyMedium;
+  final TextStyle bodySmall;
+  final TextStyle labelLarge;
+  final TextStyle labelMidium;
+  final TextStyle labelSmall;
+
+  @override
+  ThemeExtension<AppTextThemeExtension> copyWith({
+    TextStyle? displayLarge,
+    TextStyle? displayMedium,
+    TextStyle? displaySmall,
+    TextStyle? headlineLarge,
+    TextStyle? headlineMedium,
+    TextStyle? headlineSmall,
+    TextStyle? titleLarge,
+    TextStyle? titleMedium,
+    TextStyle? titleSmall,
+    TextStyle? bodyLarge,
+    TextStyle? bodyMedium,
+    TextStyle? bodySmall,
+    TextStyle? labelLarge,
+    TextStyle? labelMidium,
+    TextStyle? labelSmall,
+  }) {
+    return AppTextThemeExtension(
+      displayLarge: displayLarge ?? this.displayLarge,
+      displayMedium: displayMedium ?? this.displayMedium,
+      displaySmall: displaySmall ?? this.displaySmall,
+      headlineLarge: headlineLarge ?? this.headlineLarge,
+      headlineMedium: headlineMedium ?? this.headlineMedium,
+      headlineSmall: headlineSmall ?? this.headlineSmall,
+      titleLarge: titleLarge ?? this.titleLarge,
+      titleMedium: titleMedium ?? this.titleMedium,
+      titleSmall: titleSmall ?? this.titleSmall,
+      bodyLarge: bodyLarge ?? this.bodyLarge,
+      bodyMedium: bodyMedium ?? this.bodyMedium,
+      bodySmall: bodySmall ?? this.bodySmall,
+      labelLarge: labelLarge ?? this.labelLarge,
+      labelMidium: labelMidium ?? this.labelMidium,
+      labelSmall: labelSmall ?? this.labelSmall,
+    );
+  }
+
+  @override
+  ThemeExtension<AppTextThemeExtension> lerp(
+    covariant ThemeExtension<AppTextThemeExtension>? other,
+    double t,
+  ) {
+    if (other is! AppTextThemeExtension) {
+      return this;
+    }
+
+    return AppTextThemeExtension(
+      displayLarge: TextStyle.lerp(displayLarge, other.displayLarge, t)!,
+      displayMedium: TextStyle.lerp(displayMedium, other.displayMedium, t)!,
+      displaySmall: TextStyle.lerp(displaySmall, other.displaySmall, t)!,
+      headlineLarge: TextStyle.lerp(headlineLarge, other.headlineLarge, t)!,
+      headlineMedium: TextStyle.lerp(headlineMedium, other.headlineMedium, t)!,
+      headlineSmall: TextStyle.lerp(headlineSmall, other.headlineSmall, t)!,
+      titleLarge: TextStyle.lerp(titleLarge, other.titleLarge, t)!,
+      titleMedium: TextStyle.lerp(titleMedium, other.titleMedium, t)!,
+      titleSmall: TextStyle.lerp(titleSmall, other.titleSmall, t)!,
+      bodyLarge: TextStyle.lerp(bodyLarge, other.bodyLarge, t)!,
+      bodyMedium: TextStyle.lerp(bodyMedium, other.bodyMedium, t)!,
+      bodySmall: TextStyle.lerp(bodySmall, other.bodySmall, t)!,
+      labelLarge: TextStyle.lerp(labelLarge, other.labelLarge, t)!,
+      labelMidium: TextStyle.lerp(labelMidium, other.labelMidium, t)!,
+      labelSmall: TextStyle.lerp(labelSmall, other.labelSmall, t)!,
+    );
+  }
+}

--- a/lib/widget/theme/app_theme.dart
+++ b/lib/widget/theme/app_theme.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:quick_flutter/systems/color.dart';
+import 'package:quick_flutter/widget/theme/app_color_theme_extension.dart';
+import 'package:quick_flutter/widget/theme/app_text_theme_extension.dart';
+
+class AppTheme {
+  static final light = () {
+    final defaultTheme = ThemeData.light();
+
+    final colorExt = AppColorsExtension(
+      textDefault: const Color(0xff1F1F1F),
+      textSubtle: const Color(0xff5C5C5C),
+      textDisabled: const Color(0xff9E9E9E),
+      textDanger: const Color(0xffC20B2A),
+      textSuccess: const Color(0xff218011),
+      backgroundDefault: const Color(0xffFBFBFB),
+      backgroundSubtle: const Color(0xffF4F4F4),
+      backgroundPrimaryContainer: const Color(0xffF6EDFF),
+      backgroundPrimaryActionEnabled: const Color(0xff4F378B),
+      backgroundPrimaryActionDisabled: const Color(0xff21005D),
+      backgroundPrimaryActionHovered: const Color(0xff381E72),
+    );
+
+    return defaultTheme.copyWith(
+      colorScheme: ColorScheme.fromSeed(
+        seedColor: AppColor.seed,
+        outline: AppColor.outline,
+        outlineVariant: AppColor.outlineVariant,
+        shadow: AppColor.shadow,
+      ),
+      extensions: [
+        colorExt,
+        AppTextThemeExtension(
+          displayLarge: TextStyle(fontSize: 57, color: colorExt.textDefault),
+          displayMedium: TextStyle(fontSize: 45, color: colorExt.textDefault),
+          displaySmall: TextStyle(fontSize: 36, color: colorExt.textDefault),
+          headlineLarge: TextStyle(fontSize: 32, color: colorExt.textDefault),
+          headlineMedium: TextStyle(fontSize: 28, color: colorExt.textDefault),
+          headlineSmall: TextStyle(fontSize: 24, color: colorExt.textDefault),
+          titleLarge: TextStyle(fontSize: 22, color: colorExt.textDefault),
+          titleMedium: TextStyle(fontSize: 16, color: colorExt.textDefault),
+          titleSmall: TextStyle(fontSize: 14, color: colorExt.textDefault),
+          bodyLarge: TextStyle(fontSize: 16, color: colorExt.textDefault),
+          bodyMedium: TextStyle(fontSize: 14, color: colorExt.textDefault),
+          bodySmall: TextStyle(fontSize: 12, color: colorExt.textDefault),
+          labelLarge: TextStyle(
+            fontSize: 14,
+            fontWeight: FontWeight.bold,
+            color: colorExt.textDefault,
+          ),
+          labelMidium: TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.bold,
+            color: colorExt.textDefault,
+          ),
+          labelSmall: TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.bold,
+            color: colorExt.textDefault,
+          ),
+        ),
+      ],
+    );
+  }();
+
+  static final dark = () {
+    final defaultTheme = ThemeData.dark();
+
+    final colorExt = AppColorsExtension(
+      textDefault: Colors.white,
+      textSubtle: const Color(0xff5C5C5C),
+      textDisabled: const Color(0xff9E9E9E),
+      textDanger: const Color(0xffC20B2A),
+      textSuccess: const Color(0xff218011),
+      backgroundDefault: const Color(0xffFBFBFB),
+      backgroundSubtle: const Color(0xffF4F4F4),
+      backgroundPrimaryContainer: const Color(0xffF6EDFF),
+      backgroundPrimaryActionEnabled: const Color(0xff4F378B),
+      backgroundPrimaryActionDisabled: const Color(0xff21005D),
+      backgroundPrimaryActionHovered: const Color(0xff381E72),
+    );
+
+    return defaultTheme.copyWith(
+      colorScheme: ColorScheme.fromSeed(
+        seedColor: AppColor.seed,
+        outline: AppColor.outline,
+        outlineVariant: AppColor.outlineVariant,
+        shadow: AppColor.shadow,
+      ),
+      extensions: [
+        colorExt,
+        AppTextThemeExtension(
+          displayLarge: TextStyle(fontSize: 57, color: colorExt.textDefault),
+          displayMedium: TextStyle(fontSize: 45, color: colorExt.textDefault),
+          displaySmall: TextStyle(fontSize: 36, color: colorExt.textDefault),
+          headlineLarge: TextStyle(fontSize: 32, color: colorExt.textDefault),
+          headlineMedium: TextStyle(fontSize: 28, color: colorExt.textDefault),
+          headlineSmall: TextStyle(fontSize: 24, color: colorExt.textDefault),
+          titleLarge: TextStyle(fontSize: 22, color: colorExt.textDefault),
+          titleMedium: TextStyle(fontSize: 16, color: colorExt.textDefault),
+          titleSmall: TextStyle(fontSize: 14, color: colorExt.textDefault),
+          bodyLarge: TextStyle(fontSize: 16, color: colorExt.textDefault),
+          bodyMedium: TextStyle(fontSize: 14, color: colorExt.textDefault),
+          bodySmall: TextStyle(fontSize: 12, color: colorExt.textDefault),
+          labelLarge: TextStyle(
+            fontSize: 14,
+            fontWeight: FontWeight.bold,
+            color: colorExt.textDefault,
+          ),
+          labelMidium: TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.bold,
+            color: colorExt.textDefault,
+          ),
+          labelSmall: TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.bold,
+            color: colorExt.textDefault,
+          ),
+        ),
+      ],
+    );
+  }();
+}
+
+extension AppThemeExtension on BuildContext {
+  AppTextThemeExtension get appTextTheme {
+    return Theme.of(this).extension<AppTextThemeExtension>()!;
+  }
+
+  AppColorsExtension get appColors {
+    return Theme.of(this).extension<AppColorsExtension>()!;
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

オッス！オラ悟空だ！おめぇのPullRequestのリリースノートを作ってみたぞ！

- 新機能: `app_theme.dart`を追加して、アプリ全体の色テーマとテキストテーマを一元管理できるようにしたぞ。
- リファクタ: `quick_flutter`パッケージ内の色関連のコードを整理し、新しい`AppColorsExtension`と`AppTextThemeExtension`を導入したぞ。

これらの変更により、アプリの見た目が柔軟に変更できるようになったぞ。ただし、外部インターフェースや挙動に影響を与える可能性があるから、注意して使ってくれよな！
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->